### PR TITLE
feat: #156 Redirect `/home` to `/` in Nuxt app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ logs
 .env
 .env.*
 !.env.example
+
+# Local Netlify folder
+.netlify

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,6 +40,15 @@ export default defineNuxtConfig({
     }
   },
 
+  routeRules: {
+    '/home': {
+      redirect: {
+        to: '/',
+        statusCode: 301
+      }
+    }
+  },
+
   app: {
     head: {
       meta: [


### PR DESCRIPTION
Redirect /home to / in Nuxt app
Fixes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool configuration to exclude Netlify-related files from version control, ensuring local development environments remain separate from the repository
  * Configured permanent URL routing to redirect `/home` requests to the application's root path, enhancing user navigation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->